### PR TITLE
Set a poolCfg in context for Stream interceptor as well

### DIFF
--- a/grpcgcp/gcp_interceptor.go
+++ b/grpcgcp/gcp_interceptor.go
@@ -135,6 +135,12 @@ func (gcpInt *GCPInterceptor) GCPStreamClientInterceptor(
 ) (grpc.ClientStream, error) {
 	// This constructor does not create a real ClientStream,
 	// it only stores all parameters and let SendMsg() to create ClientStream.
+	affinityCfg, _ := gcpInt.methodToAffinity[method]
+	gcpCtx := &gcpContext{
+		affinityCfg: affinityCfg,
+		poolCfg:     gcpInt.poolCfg,
+	}
+	ctx = context.WithValue(ctx, gcpKey, gcpCtx)
 	cs := &gcpClientStream{
 		gcpInt:   gcpInt,
 		ctx:      ctx,


### PR DESCRIPTION
Without this poolCfg, if I make stream RPCs with this interceptor, it crashes because of null pointer dereferencing at https://github.com/GoogleCloudPlatform/grpc-gcp-go/blob/master/grpcgcp/gcp_picker.go#L124

Since the line checks for poolCfg.maxStreams, I am assuming setting the poolCfg is the right fix - let me know otherwise.