### PR TITLE
feat: wait until SubConn is ready for round-robin bind

### DIFF
--- a/grpcgcp/gcp_balancer_test.go
+++ b/grpcgcp/gcp_balancer_test.go
@@ -618,13 +618,14 @@ func TestRoundRobinForBind(t *testing.T) {
 	scs := []*mocks.MockSubConn{}
 	mockCC := mocks.NewMockClientConn(mockCtrl)
 	mockCC.EXPECT().UpdateState(gomock.Any()).AnyTimes()
+	mockCC.EXPECT().RemoveSubConn(gomock.Any()).Times(1)
 	mockCC.EXPECT().NewSubConn(gomock.Any(), gomock.Any()).DoAndReturn(func(_, _ interface{}) (*mocks.MockSubConn, error) {
 		newSC := mocks.NewMockSubConn(mockCtrl)
 		newSC.EXPECT().Connect().MinTimes(1)
 		newSC.EXPECT().UpdateAddresses(gomock.Any()).AnyTimes()
 		scs = append(scs, newSC)
 		return newSC, nil
-	}).Times(4)
+	}).Times(5)
 
 	b := newBuilder().Build(mockCC, balancer.BuildOptions{}).(*gcpBalancer)
 	// Simulate ClientConn calls UpdateClientConnState with the config provided to Dial.
@@ -667,10 +668,29 @@ func TestRoundRobinForBind(t *testing.T) {
 		t.Fatalf("gcpPicker.Pick returns %v, %v, want: %v, nil", pr.SubConn, err, want)
 	}
 
+	start := time.Now()
+	delay := time.Millisecond * 345
+	margin := time.Millisecond * 50
+	// Bring other subconns to ready with some delay.
+	go func() {
+		time.Sleep(delay)
+		b.UpdateSubConnState(scs[0], balancer.SubConnState{ConnectivityState: connectivity.Ready})
+		b.UpdateSubConnState(scs[2], balancer.SubConnState{ConnectivityState: connectivity.Ready})
+	}()
+
 	// Expect 0 subconn because the picker should pick even non-ready subcons for binding calls in a round-robin manner.
 	pr, err = b.picker.Pick(balancer.PickInfo{FullMethodName: "dummyService/createSession", Ctx: context.TODO()})
 	if want := scs[0]; pr.SubConn != want || err != nil {
 		t.Fatalf("gcpPicker.Pick returns %v, %v, want: %v, nil", pr.SubConn, err, want)
+	}
+
+	// Also, when round-robin for bind operations is enabled, the picker must wait until subconn became ready.
+	elapsed := time.Now().Sub(start)
+	if elapsed < delay {
+		t.Fatalf("gcpPicker.Pick returns before subconn became active")
+	}
+	if elapsed > delay+margin {
+		t.Fatalf("gcpPicker.Pick waited too long after subcon became active: %v, want <=%v", delay+margin-elapsed, margin)
 	}
 
 	pr, err = b.picker.Pick(balancer.PickInfo{FullMethodName: "dummyService/createSession", Ctx: context.TODO()})
@@ -693,10 +713,6 @@ func TestRoundRobinForBind(t *testing.T) {
 	if want := scs[1]; pr.SubConn != want || err != nil {
 		t.Fatalf("gcpPicker.Pick returns %v, %v, want: %v, nil", pr.SubConn, err, want)
 	}
-
-	// Bring other subconns to ready.
-	b.UpdateSubConnState(scs[0], balancer.SubConnState{ConnectivityState: connectivity.Ready})
-	b.UpdateSubConnState(scs[2], balancer.SubConnState{ConnectivityState: connectivity.Ready})
 
 	// Create more regular calls to reach the limit (watermark*subconns - 6 calls initiated above) to spawn new subconn.
 	for i := 0; i < streamsWatermark*minSize-6; i++ {
@@ -722,10 +738,27 @@ func TestRoundRobinForBind(t *testing.T) {
 		t.Fatalf("gcpPicker.Pick returns %v, %v, want: %v, nil", pr.SubConn, err, want)
 	}
 
+	// Instead of moving subconn 3 to ready, we replace that with subconn 4 and make that ready
+	// to test that we catch replaced subconn state change. All this happens after Pick is called.
+	go func() {
+		start = time.Now()
+		time.Sleep(delay)
+		b.refresh(b.scRefs[scs[3]])
+		b.UpdateSubConnState(scs[4], balancer.SubConnState{ConnectivityState: connectivity.Ready})
+	}()
+
 	// Extends to newly created subconn.
 	pr, err = b.picker.Pick(balancer.PickInfo{FullMethodName: "dummyService/createSession", Ctx: context.TODO()})
-	if want := scs[3]; pr.SubConn != want || err != nil {
+	if want := scs[4]; pr.SubConn != want || err != nil {
 		t.Fatalf("gcpPicker.Pick returns %v, %v, want: %v, nil", pr.SubConn, err, want)
+	}
+
+	elapsed = time.Now().Sub(start)
+	if elapsed < delay {
+		t.Fatalf("gcpPicker.Pick returns before subconn became active")
+	}
+	if elapsed > delay+margin {
+		t.Fatalf("gcpPicker.Pick waited too long after subcon became active: %v, want <=%v", delay+margin-elapsed, margin)
 	}
 
 	// Cycles to the first subconn.

--- a/grpcgcp/gcp_picker.go
+++ b/grpcgcp/gcp_picker.go
@@ -79,7 +79,7 @@ func (p *gcpPicker) Pick(info balancer.PickInfo) (balancer.PickResult, error) {
 		}
 	}
 
-	scRef, err := p.getAndIncrementSubConnRef(boundKey, cmd)
+	scRef, err := p.getAndIncrementSubConnRef(info.Ctx, boundKey, cmd)
 	if err != nil {
 		return balancer.PickResult{}, err
 	}
@@ -150,9 +150,9 @@ func (p *gcpPicker) detectUnresponsive(ctx context.Context, scRef *subConnRef, c
 	}
 }
 
-func (p *gcpPicker) getAndIncrementSubConnRef(boundKey string, cmd grpc_gcp.AffinityConfig_Command) (*subConnRef, error) {
+func (p *gcpPicker) getAndIncrementSubConnRef(ctx context.Context, boundKey string, cmd grpc_gcp.AffinityConfig_Command) (*subConnRef, error) {
 	if cmd == grpc_gcp.AffinityConfig_BIND && p.gb.cfg.GetChannelPool().GetBindPickStrategy() == grpc_gcp.ChannelPoolConfig_ROUND_ROBIN {
-		scRef := p.gb.getSubConnRoundRobin()
+		scRef := p.gb.getSubConnRoundRobin(ctx)
 		if p.log.V(FINEST) {
 			p.log.Infof("picking SubConn for round-robin bind: %p", scRef.subConn)
 		}

--- a/grpcgcp/gcp_picker.go
+++ b/grpcgcp/gcp_picker.go
@@ -174,6 +174,7 @@ func (p *gcpPicker) getAndIncrementSubConnRef(boundKey string, cmd grpc_gcp.Affi
 
 // getSubConnRef returns the subConnRef object that contains the subconn
 // ready to be used by picker.
+// Must be called holding the picker mutex lock.
 func (p *gcpPicker) getSubConnRef(boundKey string) (*subConnRef, error) {
 	if boundKey != "" {
 		if ref, ok := p.gb.getReadySubConnRef(boundKey); ok {
@@ -184,6 +185,7 @@ func (p *gcpPicker) getSubConnRef(boundKey string) (*subConnRef, error) {
 	return p.getLeastBusySubConnRef()
 }
 
+// Must be called holding the picker mutex lock.
 func (p *gcpPicker) getLeastBusySubConnRef() (*subConnRef, error) {
 	minScRef := p.scRefs[0]
 	minStreamsCnt := minScRef.getStreamsCnt()

--- a/grpcgcp/gcp_picker.go
+++ b/grpcgcp/gcp_picker.go
@@ -151,18 +151,18 @@ func (p *gcpPicker) detectUnresponsive(ctx context.Context, scRef *subConnRef, c
 }
 
 func (p *gcpPicker) getAndIncrementSubConnRef(boundKey string, cmd grpc_gcp.AffinityConfig_Command) (*subConnRef, error) {
-	p.mu.Lock()
-	defer p.mu.Unlock()
-	var scRef *subConnRef
-	var err error
 	if cmd == grpc_gcp.AffinityConfig_BIND && p.gb.cfg.GetChannelPool().GetBindPickStrategy() == grpc_gcp.ChannelPoolConfig_ROUND_ROBIN {
-		scRef = p.gb.getSubConnRoundRobin()
+		scRef := p.gb.getSubConnRoundRobin()
 		if p.log.V(FINEST) {
 			p.log.Infof("picking SubConn for round-robin bind: %p", scRef.subConn)
 		}
-	} else {
-		scRef, err = p.getSubConnRef(boundKey)
+		scRef.streamsIncr()
+		return scRef, nil
 	}
+
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	scRef, err := p.getSubConnRef(boundKey)
 	if err != nil {
 		return nil, err
 	}

--- a/grpcgcp/gcp_picker_test.go
+++ b/grpcgcp/gcp_picker_test.go
@@ -255,21 +255,25 @@ func TestPickSubConnWithLeastStreams(t *testing.T) {
 	var scRefs = []*subConnRef{
 		{
 			subConn:     mocks.NewMockSubConn(mockCtrl),
+			stateSignal: make(chan struct{}),
 			affinityCnt: 0,
 			streamsCnt:  1,
 		},
 		{
 			subConn:     okSC,
+			stateSignal: make(chan struct{}),
 			affinityCnt: 0,
 			streamsCnt:  0,
 		},
 		{
 			subConn:     mocks.NewMockSubConn(mockCtrl),
+			stateSignal: make(chan struct{}),
 			affinityCnt: 0,
 			streamsCnt:  3,
 		},
 		{
 			subConn:     mocks.NewMockSubConn(mockCtrl),
+			stateSignal: make(chan struct{}),
 			affinityCnt: 0,
 			streamsCnt:  5,
 		},
@@ -308,6 +312,7 @@ func TestPickNewSubConn(t *testing.T) {
 	var scRefs = []*subConnRef{
 		{
 			subConn:     mockSC,
+			stateSignal: make(chan struct{}),
 			affinityCnt: 0,
 			streamsCnt:  100,
 		},
@@ -366,11 +371,13 @@ func TestBindSubConn(t *testing.T) {
 	mp := make(map[balancer.SubConn]*subConnRef)
 	mp[scBusy] = &subConnRef{
 		subConn:     scBusy,
+		stateSignal: make(chan struct{}),
 		affinityCnt: 0,
 		streamsCnt:  5,
 	}
 	mp[scIdle] = &subConnRef{
 		subConn:     scIdle,
+		stateSignal: make(chan struct{}),
 		affinityCnt: 0,
 		streamsCnt:  0,
 	}
@@ -453,11 +460,13 @@ func TestPickMappedSubConn(t *testing.T) {
 	mp := make(map[balancer.SubConn]*subConnRef)
 	mp[mockSCnotmapped] = &subConnRef{
 		subConn:     mockSCnotmapped,
+		stateSignal: make(chan struct{}),
 		affinityCnt: 0,
 		streamsCnt:  0,
 	}
 	mp[mockSCmapped] = &subConnRef{
 		subConn:     mockSCmapped,
+		stateSignal: make(chan struct{}),
 		affinityCnt: 0,
 		streamsCnt:  5,
 	}


### PR DESCRIPTION
Before returning a scRef for a round-robin "bind" call we must make sure the scRef's SubConn is ready.
Otherwise, the call may re-pick a SubConn after realizing it is not ready and this breaks the round-robin pattern.