### PR TITLE
Fix invalid `go_package` proto option

### DIFF
--- a/grpcgcp/grpc_gcp/grpc_gcp.proto
+++ b/grpcgcp/grpc_gcp/grpc_gcp.proto
@@ -14,7 +14,7 @@
 
 syntax = "proto3";
 
-option go_package = "./grpc_gcp";
+option go_package = "github.com/GoogleCloudPlatform/grpc-gcp-go/grpcgcp/grpc_gcp";
 
 package grpc.gcp;
 


### PR DESCRIPTION
`go_package` has to be set to a full importpath (see https://github.com/golang/protobuf/issues/1249#issuecomment-737067539). The invalid value leads to errors when this module is consumed by [gazelle](https://github.com/bazelbuild/bazel-gazelle).