### PR TITLE
Embed balancer.SubConn in generated MockSubConn

### DIFF
--- a/grpcgcp/mocks/mock_balancer.go
+++ b/grpcgcp/mocks/mock_balancer.go
@@ -114,6 +114,9 @@ func (mr *MockClientConnMockRecorder) UpdateState(arg0 interface{}) *gomock.Call
 
 // MockSubConn is a mock of SubConn interface.
 type MockSubConn struct {
+	// The SubConn interface is added by a manual edit to 
+	// comply with the requirements in the SubConn interface
+	// doc comment.
 	balancer.SubConn
 	ctrl     *gomock.Controller
 	recorder *MockSubConnMockRecorder

--- a/grpcgcp/mocks/mock_balancer.go
+++ b/grpcgcp/mocks/mock_balancer.go
@@ -114,6 +114,7 @@ func (mr *MockClientConnMockRecorder) UpdateState(arg0 interface{}) *gomock.Call
 
 // MockSubConn is a mock of SubConn interface.
 type MockSubConn struct {
+	balancer.SubConn
 	ctrl     *gomock.Controller
 	recorder *MockSubConnMockRecorder
 }


### PR DESCRIPTION
The [doc comment on balancer.SubConn](https://pkg.go.dev/google.golang.org/grpc@v1.67.1/balancer#SubConn) mentions that users should embed the interface so that gRPC Go can add methods to it without breaking them. In [#7758](https://github.com/grpc/grpc-go/pull/7758), grpc-go will enforce this requirement at compile time by adding an unexported method in the interface. From my reading about Gomock, it doesn't seem to support generating code with the interface already embedded. To avoid breaking the tests using this mock, this PR manually edits the mock to embed the interface.