### PR TITLE
Embed balancer.ClientConn in MockClientConn

### DIFF
--- a/grpcgcp/mocks/mock_balancer.go
+++ b/grpcgcp/mocks/mock_balancer.go
@@ -14,6 +14,10 @@ import (
 
 // MockClientConn is a mock of ClientConn interface.
 type MockClientConn struct {
+	// The ClientConn interface below is embedded by a manual edit to comply 
+	// with grpc's requirement to embed an existing ClientConn to allow grpc to
+	// add new methods to the interface easily.
+	balancer.ClientConn
 	ctrl     *gomock.Controller
 	recorder *MockClientConnMockRecorder
 }


### PR DESCRIPTION
In https://github.com/grpc/grpc-go/pull/8026, grpc-go plans to enforce users embed existing instances of a ClientConn in their ClientConn wrappers. This allows gRPC Go to add methods to the interface without breaking users, the new methods would be passed through the embedded ClientConn. To avoid breaking the tests using the MockBalancer generated by gomock, this PR manually edits the mock to embed the interface. 

A similar PR (https://github.com/GoogleCloudPlatform/grpc-gcp-go/pull/89) was set out when grpc-go was enforcing an embedding requirement for implementors of balancer.SubConn.