### PR TITLE
continuous-load-testing: Update resources in us-east7 region

### DIFF
--- a/continuous_load_testing/client-go-cloudpath-useast7.yaml
+++ b/continuous_load_testing/client-go-cloudpath-useast7.yaml
@@ -34,8 +34,8 @@ spec:
           value: k8s.pod.name=$(POD_NAME),k8s.namespace.name=$(NAMESPACE_NAME),k8s.container.name=$(CONTAINER_NAME)
         resources:
           requests:
-            cpu: "2"
-            memory: "256Mi"
+            cpu: "1"
+            memory: "128Mi"
           limits:
-            cpu: "2"
-            memory: "1024Mi"
+            cpu: "1"
+            memory: "512Mi"

--- a/continuous_load_testing/client-go-useast7.yaml
+++ b/continuous_load_testing/client-go-useast7.yaml
@@ -34,8 +34,8 @@ spec:
           value: k8s.pod.name=$(POD_NAME),k8s.namespace.name=$(NAMESPACE_NAME),k8s.container.name=$(CONTAINER_NAME)
         resources:
           requests:
-            cpu: "2"
-            memory: "256Mi"
+            cpu: "1"
+            memory: "128Mi"
           limits:
-            cpu: "2"
-            memory: "1024Mi"
+            cpu: "1"
+            memory: "512Mi"


### PR DESCRIPTION
The GKE deployments in us-east7 failed due to insufficient CPU resources. See the screenshot for details: https://screenshot.googleplex.com/AZZRpSPn6U4FMak."