### PR TITLE
Add docker image for gcs go benchmark client

### DIFF
--- a/e2e-examples/gcs/docker/BUILDING.md
+++ b/e2e-examples/gcs/docker/BUILDING.md
@@ -1,0 +1,19 @@
+### How to build and upload it to the registry
+
+This is an example that the gRPC team uses internally, so you may need to
+change `IMAGE_NAME` for your needs.
+
+#### Build and upload new docker image
+
+Update the `IMAGE_VERSION` to match the version of the image you want to use.
+
+From the `e2e-examples/gcs` directory:
+
+```
+$ export IMAGE_NAME=us-docker.pkg.dev/grpc-testing/testing-images-public/grpc-gcp-go-gcs-benchmark
+$ export IMAGE_VERSION=20250601.0
+$ docker build -t $IMAGE_NAME:$IMAGE_VERSION -f docker/Dockerfile ../
+$ docker push $IMAGE_NAME:$IMAGE_VERSION
+$ docker tag $IMAGE_NAME:$IMAGE_VERSION $IMAGE_NAME:latest
+$ docker push $IMAGE_NAME:latest
+```

--- a/e2e-examples/gcs/docker/Dockerfile
+++ b/e2e-examples/gcs/docker/Dockerfile
@@ -1,0 +1,23 @@
+# Copyright 2025 gRPC authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+FROM golang:1.23-bookworm
+
+WORKDIR /var/grpc
+
+COPY . .
+
+RUN go build gcs/main.go
+
+ENTRYPOINT ["/var/grpc/main"]


### PR DESCRIPTION
This will work in conjunction with the internal benchmark test that we are going to run.